### PR TITLE
Add slot aware raw action

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ This configuration parameter defines which slots should be analysed for semantic
 
 This configuration option specifies whether to purge the page after a slot edit is performed.
 
+### `$WSSlotsOverrideRawAction`
+
+If enabled, we overwrite the default [RawAction](https://m.mediawiki.org/wiki/Manual:RawAction.php) with a slot-aware implementation when a slot parameter is provided, e. g. `action=raw&slot=someslot` with `action=rawslot&slot=someslot`.
+
 ## Parser functions
 
 ### `#slot`
@@ -67,4 +71,12 @@ The syntax of the parser function is as follows:
 
 ```
 {{#slottemplates: <slotname> | <pagename> | <arrayname> | <recursive> }}
+```
+
+## Actions ##
+
+### `rawslot` ###
+Slot-aware version of `action=raw` (see [RawAction](https://m.mediawiki.org/wiki/Manual:RawAction.php)). Returns the content of the specified slot as raw value (format depends on the slot content model). Example:
+```
+/wiki/MyMultislotPage?action=rawslot&slot=someslot
 ```

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ This configuration parameter defines which slots should be analysed for semantic
 
 This configuration option specifies whether to purge the page after a slot edit is performed.
 
-### `$WSSlotsOverrideRawAction`
+### `$wgWSSlotsOverrideRawAction`
 
-If enabled, we overwrite the default [RawAction](https://m.mediawiki.org/wiki/Manual:RawAction.php) with a slot-aware implementation when a slot parameter is provided, e. g. `action=raw&slot=someslot` with `action=rawslot&slot=someslot`.
+If enabled, the default [RawAction](https://m.mediawiki.org/wiki/Manual:RawAction.php) gets replaced by a slot-aware implementation when a slot parameter is provided, e. g. `action=raw&slot=someslot` with `action=rawslot&slot=someslot`.
 
 ## Parser functions
 
@@ -80,3 +80,10 @@ Slot-aware version of `action=raw` (see [RawAction](https://m.mediawiki.org/wiki
 ```
 /wiki/MyMultislotPage?action=rawslot&slot=someslot
 ```
+
+If `$wgWSSlotsOverrideRawAction == true`, this request is equivalent to
+```
+/wiki/MyMultislotPage?action=raw&slot=someslot
+```
+
+

--- a/extension.json
+++ b/extension.json
@@ -20,13 +20,17 @@
   "AutoloadNamespaces": {
     "WSSlots\\": "src/"
   },
+  "AutoloadClasses": {
+		"SlotAwareRawAction": "src/Action/SlotAwareRawAction.php"
+	},
   "Hooks": {
     "MediaWikiServices": "main",
     "ParserFirstCallInit": "main",
     "ListDefinedTags": "main",
     "ChangeTagsListActive": "main",
     "SMW::Store::BeforeDataUpdateComplete": "\\WSSlots\\WSSlotsHooks::onBeforeDataUpdateComplete",
-    "ScribuntoExternalLibraries": "\\WSSlots\\WSSlotsHooks::onScribuntoExternalLibraries"
+    "ScribuntoExternalLibraries": "\\WSSlots\\WSSlotsHooks::onScribuntoExternalLibraries",
+    "BeforeInitialize": "\\WSSlots\\WSSlotsHooks::onBeforeInitialize"
   },
   "HookHandlers": {
     "main": {
@@ -55,6 +59,9 @@
     },
     "WSSlotsDoPurge": {
       "value": false
+    },
+    "WSSlotsOverrideRawAction": {
+      "value": false
     }
   },
   "APIModules": {
@@ -62,6 +69,9 @@
     "editslot": "WSSlots\\API\\ApiEditSlot",
     "readslot": "WSSlots\\API\\ApiReadSlot"
   },
+  "Actions": {
+		"rawslot": "SlotAwareRawAction"
+	},
   "manifest_version": 2,
   "load_composer_autoloader": true
 }

--- a/src/Action/SlotAwareRawAction.php
+++ b/src/Action/SlotAwareRawAction.php
@@ -1,0 +1,307 @@
+<?php
+/**
+ * Raw page text accessor
+ *
+ * Copyright © 2004 Gabriel Wicke <wicke@wikidev.net>
+ * http://wikidev.net/
+ *
+ * Based on HistoryAction and SpecialExport
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * http://www.gnu.org/copyleft/gpl.html
+ *
+ * @author Gabriel Wicke <wicke@wikidev.net>
+ * @file
+ */
+
+use MediaWiki\Logger\LoggerFactory;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Revision\SlotRecord;
+
+/**
+ * A simple method to retrieve the plain source of an article,
+ * using "action=raw" in the GET request string.
+ *
+ * @ingroup Actions
+ */
+class RawAction extends FormlessAction {
+	public function getName() {
+		return 'raw';
+	}
+
+	public function requiresWrite() {
+		return false;
+	}
+
+	public function requiresUnblock() {
+		return false;
+	}
+
+	/**
+	 * @suppress SecurityCheck-XSS Non html mime type
+	 * @return string|null
+	 */
+	public function onView() {
+		$this->getOutput()->disable();
+		$request = $this->getRequest();
+		$response = $request->response();
+		$config = $this->context->getConfig();
+
+		if ( $this->getOutput()->checkLastModified(
+			$this->getWikiPage()->getTouched()
+		) ) {
+			return null; // Client cache fresh and headers sent, nothing more to do.
+		}
+
+		$contentType = $this->getContentType();
+
+		$maxage = $request->getInt( 'maxage', $config->get( 'CdnMaxAge' ) );
+		$smaxage = $request->getIntOrNull( 'smaxage' );
+		if ( $smaxage === null ) {
+			if (
+				$contentType == 'text/css' ||
+				$contentType == 'application/json' ||
+				$contentType == 'text/javascript'
+			) {
+				// CSS/JSON/JS raw content has its own CDN max age configuration.
+				// Note: Title::getCdnUrls() includes action=raw for css/json/js
+				// pages, so if using the canonical url, this will get HTCP purges.
+				$smaxage = intval( $config->get( 'ForcedRawSMaxage' ) );
+			} else {
+				// No CDN cache for anything else
+				$smaxage = 0;
+			}
+		}
+
+		// Set standard Vary headers so cache varies on cookies and such (T125283)
+		$response->header( $this->getOutput()->getVaryHeader() );
+
+		$permissionManager = MediaWikiServices::getInstance()->getPermissionManager();
+		// Output may contain user-specific data;
+		// vary generated content for open sessions on private wikis
+		$privateCache = !$permissionManager->isEveryoneAllowed( 'read' ) &&
+			( $smaxage == 0 || MediaWiki\Session\SessionManager::getGlobalSession()->isPersistent() );
+		// Don't accidentally cache cookies if user is logged in (T55032)
+		$privateCache = $privateCache || $this->getUser()->isLoggedIn();
+		$mode = $privateCache ? 'private' : 'public';
+		$response->header(
+			'Cache-Control: ' . $mode . ', s-maxage=' . $smaxage . ', max-age=' . $maxage
+		);
+
+		// In the event of user JS, don't allow loading a user JS/CSS/Json
+		// subpage that has no registered user associated with, as
+		// someone could register the account and take control of the
+		// JS/CSS/Json page.
+		$title = $this->getTitle();
+		if ( $title->isUserConfigPage() && $contentType !== 'text/x-wiki' ) {
+			// not using getRootText() as we want this to work
+			// even if subpages are disabled.
+			$rootPage = strtok( $title->getText(), '/' );
+			$userFromTitle = User::newFromName( $rootPage, 'usable' );
+			if ( !$userFromTitle || $userFromTitle->getId() === 0 ) {
+				$elevated = $permissionManager->userHasRight( $this->getUser(), 'editinterface' );
+				$elevatedText = $elevated ? 'by elevated ' : '';
+				$log = LoggerFactory::getInstance( "security" );
+				$log->warning(
+					"Unsafe JS/CSS/Json {$elevatedText}load - {user} loaded {title} with {ctype}",
+					[
+						'user' => $this->getUser()->getName(),
+						'title' => $title->getPrefixedDBkey(),
+						'ctype' => $contentType,
+						'elevated' => $elevated
+					]
+				);
+				$msg = wfMessage( 'unregistered-user-config' );
+				throw new HttpError( 403, $msg );
+			}
+		}
+
+		// Don't allow loading non-protected pages as javascript.
+		// In future we may further restrict this to only CONTENT_MODEL_JAVASCRIPT
+		// in NS_MEDIAWIKI or NS_USER, as well as including other config types,
+		// but for now be more permissive. Allowing protected pages outside of
+		// NS_USER and NS_MEDIAWIKI in particular should be considered a temporary
+		// allowance.
+		if (
+			$contentType === 'text/javascript' &&
+			!$title->isUserJsConfigPage() &&
+			!$title->inNamespace( NS_MEDIAWIKI ) &&
+			!in_array( 'sysop', $title->getRestrictions( 'edit' ) ) &&
+			!in_array( 'editprotected', $title->getRestrictions( 'edit' ) )
+		) {
+
+			$log = LoggerFactory::getInstance( "security" );
+			$log->info( "Blocked loading unprotected JS {title} for {user}",
+				[
+					'user' => $this->getUser()->getName(),
+					'title' => $title->getPrefixedDBkey(),
+				]
+			);
+			throw new HttpError( 403, wfMessage( 'unprotected-js' ) );
+		}
+
+		$response->header( 'Content-type: ' . $contentType . '; charset=UTF-8' );
+
+		$text = $this->getRawText();
+
+		// Don't return a 404 response for CSS or JavaScript;
+		// 404s aren't generally cached and it would create
+		// extra hits when user CSS/JS are on and the user doesn't
+		// have the pages.
+		if ( $text === false && $contentType == 'text/x-wiki' ) {
+			$response->statusHeader( 404 );
+		}
+
+		if ( !$this->getHookRunner()->onRawPageViewBeforeOutput( $this, $text ) ) {
+			wfDebug( __METHOD__ . ": RawPageViewBeforeOutput hook broke raw page output." );
+		}
+
+		echo $text;
+
+		return null;
+	}
+
+	/**
+	 * Get the text that should be returned, or false if the page or revision
+	 * was not found.
+	 *
+	 * @return string|bool
+	 */
+	public function getRawText() {
+		$text = false;
+		$title = $this->getTitle();
+		$request = $this->getRequest();
+
+		// Get it from the DB
+		$rev = MediaWikiServices::getInstance()
+			->getRevisionLookup()
+			->getRevisionByTitle( $title, $this->getOldId() );
+		if ( $rev ) {
+			$lastmod = wfTimestamp( TS_RFC2822, $rev->getTimestamp() );
+			$request->response()->header( "Last-modified: $lastmod" );
+
+			// Public-only due to cache headers
+			$content = $rev->getContent( SlotRecord::MAIN );
+
+			if ( $content === null ) {
+				// revision not found (or suppressed)
+				$text = false;
+			} elseif ( !$content instanceof TextContent ) {
+				// non-text content
+				wfHttpError( 415, "Unsupported Media Type", "The requested page uses the content model `"
+					. $content->getModel() . "` which is not supported via this interface." );
+				die();
+			} else {
+				// want a section?
+				$section = $request->getIntOrNull( 'section' );
+				if ( $section !== null ) {
+					$content = $content->getSection( $section );
+				}
+
+				if ( $content === null || $content === false ) {
+					// section not found (or section not supported, e.g. for JS, JSON, and CSS)
+					$text = false;
+				} else {
+					$text = $content->getText();
+				}
+			}
+		}
+
+		if ( $text !== false && $text !== '' && $request->getRawVal( 'templates' ) === 'expand' ) {
+			$text = MediaWikiServices::getInstance()->getParser()->preprocess(
+				$text,
+				$title,
+				ParserOptions::newFromContext( $this->getContext() )
+			);
+		}
+
+		return $text;
+	}
+
+	/**
+	 * Get the ID of the revision that should used to get the text.
+	 *
+	 * @return int
+	 */
+	public function getOldId() {
+		$oldid = $this->getRequest()->getInt( 'oldid' );
+		$rl = MediaWikiServices::getInstance()->getRevisionLookup();
+		switch ( $this->getRequest()->getText( 'direction' ) ) {
+			case 'next':
+				# output next revision, or nothing if there isn't one
+				$nextRev = null;
+				if ( $oldid ) {
+					$oldRev = $rl->getRevisionById( $oldid );
+					if ( $oldRev ) {
+						$nextRev = $rl->getNextRevision( $oldRev );
+					}
+				}
+				$oldid = $nextRev ? $nextRev->getId() : -1;
+				break;
+			case 'prev':
+				# output previous revision, or nothing if there isn't one
+				$prevRev = null;
+				if ( !$oldid ) {
+					# get the current revision so we can get the penultimate one
+					$oldid = $this->getWikiPage()->getLatest();
+				}
+				$oldRev = $rl->getRevisionById( $oldid );
+				if ( $oldRev ) {
+					$prevRev = $rl->getPreviousRevision( $oldRev );
+				}
+				$oldid = $prevRev ? $prevRev->getId() : -1;
+				break;
+			case 'cur':
+				$oldid = 0;
+				break;
+		}
+
+		return $oldid;
+	}
+
+	/**
+	 * Get the content type to use for the response
+	 *
+	 * @return string
+	 */
+	public function getContentType() {
+		// Optimisation: Avoid slow getVal(), this isn't user-generated content.
+		$ctype = $this->getRequest()->getRawVal( 'ctype' );
+
+		if ( $ctype == '' ) {
+			// Legacy compatibilty
+			$gen = $this->getRequest()->getRawVal( 'gen' );
+			if ( $gen == 'js' ) {
+				$ctype = 'text/javascript';
+			} elseif ( $gen == 'css' ) {
+				$ctype = 'text/css';
+			}
+		}
+
+		$allowedCTypes = [
+			'text/x-wiki',
+			'text/javascript',
+			'text/css',
+			// FIXME: Should we still allow Zope editing? External editing feature was dropped
+			'application/x-zope-edit',
+			'application/json'
+		];
+		if ( $ctype == '' || !in_array( $ctype, $allowedCTypes ) ) {
+			$ctype = 'text/x-wiki';
+		}
+
+		return $ctype;
+	}
+}

--- a/src/Action/SlotAwareRawAction.php
+++ b/src/Action/SlotAwareRawAction.php
@@ -193,7 +193,10 @@ class RawAction extends FormlessAction {
 			$request->response()->header( "Last-modified: $lastmod" );
 
 			// Public-only due to cache headers
-			$content = $rev->getContent( SlotRecord::MAIN );
+			// Fetch specific slot if defined
+			$slot = $this->getRequest()->getText( 'slot' );
+			if ( $slot ) {  $content = $rev->getContent($slot); }
+			else $content = $rev->getContent( SlotRecord::MAIN );
 
 			if ( $content === null ) {
 				// revision not found (or suppressed)

--- a/src/Action/SlotAwareRawAction.php
+++ b/src/Action/SlotAwareRawAction.php
@@ -1,5 +1,10 @@
 <?php
 /**
+ * Modified version of https://github.com/wikimedia/mediawiki/blob/REL1_35/includes/actions/RawAction.php
+ * Fetches specific content slot if defined
+ * 
+ * ---------------
+ * 
  * Raw page text accessor
  *
  * Copyright © 2004 Gabriel Wicke <wicke@wikidev.net>
@@ -36,9 +41,9 @@ use MediaWiki\Revision\SlotRecord;
  *
  * @ingroup Actions
  */
-class RawAction extends FormlessAction {
+class SlotAwareRawAction extends FormlessAction {
 	public function getName() {
-		return 'raw';
+		return 'rawslot';
 	}
 
 	public function requiresWrite() {

--- a/src/WSSlotsHooks.php
+++ b/src/WSSlotsHooks.php
@@ -155,4 +155,28 @@ class WSSlotsHooks implements
 
         return true;
     }
+
+    /**
+     * Hook to extend the original RawAction on demand to fetch contents from a specific slot.
+     *
+     * @link https://www.mediawiki.org/wiki/Manual:Hooks/BeforeInitialize
+     *
+     * @param Title $title
+     * @param unused
+     * @param OutputPage $output
+     * @param User $user
+     * @param WebRequest $request
+     * @param MediaWiki $mediaWiki
+     * @return bool
+     */
+    public static function onBeforeInitialize( \Title &$title, $unused, \OutputPage $output, \User $user, \WebRequest $request, \MediaWiki $mediaWiki ) { 
+
+        $config = \MediaWiki\MediaWikiServices::getInstance()->getMainConfig();
+
+        #if enabled, we overwrite 'action=raw&slot=someslot' with 'action=rawslot&slot=someslot'
+        if ( $config->get( "WSSlotsOverrideRawAction" ) && $request->getText( 'action' ) === 'raw' && $request->getText( 'slot' )) {
+            $request->setVal( 'action', 'rawslot');
+		}
+        return true;
+    }
 }


### PR DESCRIPTION
For our usecases it is important that third party systems can directly request the content of slots in the correct format. However, the default action 'raw' only returns the main slot. 
This actually requires only a minimal change to the Mediawiki core code (see https://github.com/Open-CSP/WSSlots/commit/24e0b34de195a3e516601fe5c35b4f6f729a3cc5). Unfortunately, this is not quick to accomplish and then probably not executed as a backport (see [T324910](https://phabricator.wikimedia.org/T324910)).

Therefore, I've added a slot-aware version of `action=raw` (see [RawAction](https://m.mediawiki.org/wiki/Manual:RawAction.php)) which returns the content of the specified slot as raw value (format depends on the slot content model). Example:
```
/wiki/MyMultislotPage?action=rawslot&slot=someslot
```

To maintain forward compatibility with a possible later patching of the core, the action `raw` can also be redirected to `rawslot` by option (see ReadMe).


