### PR TITLE
rename class import SlotRecord

### DIFF
--- a/src/WSSlots.php
+++ b/src/WSSlots.php
@@ -6,7 +6,7 @@ use CommentStoreComment;
 use Content;
 use ContentHandler;
 use MediaWiki\MediaWikiServices;
-use MediaWiki\Storage\SlotRecord;
+use MediaWiki\Revision\SlotRecord;
 use MWException;
 use TextContent;
 use User;


### PR DESCRIPTION
MediaWiki\Storage\SlotRecord was renamed to MediaWiki\Revision\SlotRecord in MW 1.32 see: https://doc.wikimedia.org/mediawiki-core/master/php/classMediaWiki_1_1Revision_1_1SlotRecord.html

MW 1.35 may keep some backwards compatibility, but MW 1.39 does not