### PR TITLE
Allow for quoted keys

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "name": "WSSlots",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "namemsg": "wsslots-extensionname",
   "url": "https://wikibase-solutions.com",
   "type": "other",

--- a/src/ParserFunctions/SlotDataParserFunction.php
+++ b/src/ParserFunctions/SlotDataParserFunction.php
@@ -145,9 +145,7 @@ class SlotDataParserFunction {
 	 * @return mixed
 	 */
 	private function findBlockByPath( string $path, array $array ) {
-		if ( substr( $path, 0, 2 ) !== '$.' ) {
-			$path = '$.' . $path;
-		}
+		$path = $this->prefixPath( $path );
 
 		try {
 			$jsonObject = new JsonObject( $array );
@@ -192,4 +190,21 @@ class SlotDataParserFunction {
 
 		return null;
 	}
+
+    /**
+     * @param string $path
+     * @return string
+     */
+    private function prefixPath( string $path ): string {
+        $firstChar = substr( $path, 0, 1 );
+
+        switch ( $firstChar ) {
+            case '$':
+                return $path;
+            case '[':
+                return '$' . $path;
+            default:
+                return '$.' . $path;
+        }
+    }
 }


### PR DESCRIPTION
In order to use JSONPath with non alphanumeric keys (for instance, keys with spaces), the key needs to be quoted like so:

```
$['My special key']
```

However, this was not properly supported, because WSSlots would automatically prepend `$.` to the path, which only works for non-quoted keys. This pull request makes the prepending slightly smarter (although still quite dumb), by prepending in the following ways:

- If the path starts with `$`, nothing is prepended
- If the path starts with `[`, only a `$` is prepended
- Otherwise, `$.` is prepended

This closes #22.