### PR TITLE
Require PHP 8.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
   "keywords": [ "slots" ],
   "license": "GPL-2.0-or-later",
   "require": {
+    "php": "^8.0",
     "wikibase-solutions/mediawiki-template-parser": "^2.0",
     "galbar/jsonpath": "^2.1"
   },

--- a/extension.json
+++ b/extension.json
@@ -10,7 +10,10 @@
   "descriptionmsg": "wsslots-desc",
   "license-name": "GPL-2.0-or-later",
   "requires": {
-    "MediaWiki": ">= 1.35.0"
+    "MediaWiki": ">= 1.35.0",
+    "platform": {
+      "php": ">= 8.0"
+    }
   },
   "MessagesDirs": {
     "WSSlots": [


### PR DESCRIPTION
WSSlots silently requires PHP 8.0+ for a trailing comma in the parameter list