### PR TITLE
fix parserError in WSSlots

### DIFF
--- a/src/WSSlots.php
+++ b/src/WSSlots.php
@@ -296,7 +296,7 @@ class WSSlots {
 	protected static function getWatchlistValue(
 		string $watchlist,
 		Title $title,
-		User $user,
+		User $user
 	): bool {
 		$services = MediaWikiServices::getInstance();
 


### PR DESCRIPTION
when trying todo anything with the WSSlots it just crashes on this comma