### PR TITLE
Update deprecated ContentRenderer::getParserOutput with rev ID

### DIFF
--- a/src/WSSlotsHooks.php
+++ b/src/WSSlotsHooks.php
@@ -172,8 +172,14 @@ class WSSlotsHooks implements
 			}
 
 			if ( method_exists( $mwServices, 'getContentRenderer' ) ) {
-				$parserOutput = $mwServices->getContentRenderer()->getParserOutput( $content, $subjectTitle, $revision->getId() );
+				if ( version_compare( MW_VERSION, '1.42', '>=' ) ) {
+					$parserOutput = $mwServices->getContentRenderer()->getParserOutput( $content, $subjectTitle, $revision );
+				} else {
+					// MW 1.39-1.42
+					$parserOutput = $mwServices->getContentRenderer()->getParserOutput( $content, $subjectTitle, $revision->getId() );
+				}
 			} else {
+				// MW 1.35-1.38
 				$parserOutput = $content->getParserOutput( $subjectTitle, $revision->getId() );
 			}
 


### PR DESCRIPTION
Deprecated since MW 1.42, removed in MW 1.45.

Ref https://gerrit.wikimedia.org/r/c/mediawiki/core/+/1185125